### PR TITLE
fix(workflows): revert step-security actions to original authors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-
       - name: ✅ Require checks in PR
         uses: devantler-tech/actions/require-checks-in-pr@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0
         with:


### PR DESCRIPTION
Replace step-security forks with original upstream actions using SHA pinning, and remove `harden-runner` steps (trial expired).

## Changes

### Replaced actions
| step-security fork | Original upstream |
|---|---|
| `step-security/docker-login-action` v3.7.0 | `docker/login-action@c94ce9fb` v3.7.0 |
| `step-security/git-auto-commit-action` v7.1.0/v7.1.1 | `stefanzweifel/git-auto-commit-action@04702edd` v7.1.0 |

### Removed steps
- `step-security/harden-runner` (all versions) — trial expired, no upstream equivalent