### PR TITLE
docs: remove Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Test](https://github.com/devantler-tech/dotnet-template/actions/workflows/test.yaml/badge.svg)](https://github.com/devantler-tech/dotnet-template/actions/workflows/test.yaml)
-[![codecov](https://codecov.io/gh/devantler-tech/dotnet-template/graph/badge.svg?token=RhQPb4fE7z)](https://codecov.io/gh/devantler-tech/dotnet-template)
 
 A simple .NET template for new projects.
 


### PR DESCRIPTION
Coverage is now reported via GitHub Code Quality (native PR coverage) rather than Codecov, so the Codecov badge is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)