### PR TITLE
feat: bump target framework net9.0 → net10.0 (current LTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-`devantler-tech/dotnet-template` is a minimal .NET template for bootstrapping new .NET projects/libraries. It ships an empty, idiomatic scaffold — a library project plus a matching test project — wired up with the house defaults (nullable enabled, implicit usings, `AnalysisMode=All`, `TreatWarningsAsErrors=true`, XML doc generation) and the standard CI/CD, release, and editor/agent tooling, so a new package can start from a clean, current baseline. Targets `net9.0`; published to NuGet via the shared publish workflow.
+`devantler-tech/dotnet-template` is a minimal .NET template for bootstrapping new .NET projects/libraries. It ships an empty, idiomatic scaffold — a library project plus a matching test project — wired up with the house defaults (nullable enabled, implicit usings, `AnalysisMode=All`, `TreatWarningsAsErrors=true`, XML doc generation) and the standard CI/CD, release, and editor/agent tooling, so a new package can start from a clean, current baseline. Targets `net10.0`; published to NuGet via the shared publish workflow.
 
 ## Repository structure
 

--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AnalysisMode>All</AnalysisMode>

--- a/tests/Example.Tests/Example.Tests.csproj
+++ b/tests/Example.Tests/Example.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AnalysisMode>All</AnalysisMode>


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #168 (roadmap epic #167, direction 1 — current toolchain).

## What & why
.NET 9 is an **STS** release whose support window ends ~May 2026; **.NET 10 (LTS)** shipped Nov 2025. A template that bootstraps *new* projects should default to the current LTS so adopters start on a supported, long-lived runtime.

## Changes
- `src/Example/Example.csproj`: `<TargetFramework>` net9.0 → **net10.0**
- `tests/Example.Tests/Example.Tests.csproj`: net9.0 → **net10.0**
- `AGENTS.md`: "Targets \`net9.0\`" → **net10.0** (docs match code)

Test tooling is already net10-compatible (`Microsoft.NET.Test.Sdk` 18.3.0, `xunit` 2.9.3, `coverlet.collector` 8.0.1, `xunit.runner.visualstudio` 3.1.5) — no version bumps needed. Kept this a pure TFM + docs bump (xUnit v3 is tracked separately under #167). No `global.json`, so the SDK is whatever CI provisions.

## Prerequisite (now satisfied)
The org-required `reusable-workflows/run-dotnet-tests.yaml` provisions the test SDK; it now installs **.NET 9 + 10 side-by-side** (reusable-workflows#251, merged `b748f68`). The ruleset tracks `main`, so this PR's net10 CI runs against an SDK-10-capable runner.

## Validation (local, SDK 10.0.300)
- `dotnet build Example.slnx` → **0 warnings, 0 errors** with `TreatWarningsAsErrors` still enabled
- `dotnet test Example.slnx` → **1/1 passed** on `net10.0`

## Acceptance criteria
- [x] Both projects target net10.0; AGENTS.md reflects net10
- [x] build + test pass locally on .NET 10 with TreatWarningsAsErrors enabled
- [ ] CI required checks + publish workflow green (verified on this PR's CI)