### PR TITLE
feat: make the example exemplary (model the house testing pattern)

### DIFF
--- a/src/Example/ExampleClass.cs
+++ b/src/Example/ExampleClass.cs
@@ -1,9 +1,17 @@
 ﻿namespace Example;
 
 /// <summary>
-/// An example class.
+/// An example class that models the house conventions for this template: a single,
+/// minimal, fully-documented member with real behaviour worth asserting against.
+/// Replace it with your own type when you adopt the template.
 /// </summary>
-public class ExampleClass
+public static class ExampleClass
 {
-
+  /// <summary>
+  /// Adds two integers and returns their sum.
+  /// </summary>
+  /// <param name="augend">The first value to add.</param>
+  /// <param name="addend">The second value to add.</param>
+  /// <returns>The sum of <paramref name="augend"/> and <paramref name="addend"/>.</returns>
+  public static int Add(int augend, int addend) => augend + addend;
 }

--- a/tests/Example.Tests/ExampleClassTests.cs
+++ b/tests/Example.Tests/ExampleClassTests.cs
@@ -6,15 +6,36 @@
 public class ExampleClassTests
 {
   /// <summary>
-  /// Test that the <see cref="ExampleClass"/> class is not null
+  /// Verifies that <see cref="ExampleClass.Add(int, int)"/> returns the sum of its two operands.
   /// </summary>
   [Fact]
-  public void Test1()
+  public void Add_TwoOperands_ReturnsTheirSum()
   {
     // Arrange
-    var exampleClass = new ExampleClass();
+    int augend = 2;
+    int addend = 3;
 
-    // Act & Assert
-    Assert.NotNull(exampleClass);
+    // Act
+    int sum = ExampleClass.Add(augend, addend);
+
+    // Assert
+    Assert.Equal(5, sum);
+  }
+
+  /// <summary>
+  /// Verifies that <see cref="ExampleClass.Add(int, int)"/> treats a negative operand as a subtraction.
+  /// </summary>
+  [Fact]
+  public void Add_NegativeOperand_SubtractsFromTheOther()
+  {
+    // Arrange
+    int augend = 10;
+    int addend = -4;
+
+    // Act
+    int sum = ExampleClass.Add(augend, addend);
+
+    // Assert
+    Assert.Equal(6, sum);
   }
 }

--- a/tests/Example.Tests/ExampleClassTests.cs
+++ b/tests/Example.Tests/ExampleClassTests.cs
@@ -23,10 +23,10 @@ public class ExampleClassTests
   }
 
   /// <summary>
-  /// Verifies that <see cref="ExampleClass.Add(int, int)"/> treats a negative operand as a subtraction.
+  /// Verifies that <see cref="ExampleClass.Add(int, int)"/> returns the correct sum when one operand is negative.
   /// </summary>
   [Fact]
-  public void Add_NegativeOperand_SubtractsFromTheOther()
+  public void Add_NegativeOperand_ReturnsTheirSum()
   {
     // Arrange
     int augend = 10;


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #170 (roadmap epic #167, direction 3 — *exemplary by example*).

## Problem
The scaffold's example modeled no pattern a new project would want to copy: `ExampleClass` was an **empty** class and `Test1()` only asserted `Assert.NotNull(new ExampleClass())`. A template's job is to set the *pattern*, so the example should be exemplary while staying minimal.

## Change
- **`ExampleClass`** → one documented, idiomatic pure member: `static int Add(int augend, int addend)`. The strict house analyzers themselves dictate the shape — a pure method that touches no instance data is flagged `CA1822` (mark as static) and elevated to an error by `TreatWarningsAsErrors`, so the example models the analyzer-clean form (a `static` utility) rather than suppressing the rule.
- **Tests** → rewritten to the house convention: `Method_State_ExpectedResult` naming, explicit **Arrange / Act / Assert**, and assertions on **real behaviour** (the computed sum) instead of non-null. A second case (negative operand) shows more than the happy path.

## Acceptance criteria (all met)
- ✅ `ExampleClass` has one documented member; the example stays minimal and idiomatic.
- ✅ Tests follow `Method_State_Expected` naming with clear AAA and assert real behaviour.
- ✅ `dotnet build` + `dotnet test` (Release) pass under the house `TreatWarningsAsErrors` + `AnalysisMode=All`: **0 warnings, 2 tests pass** locally.

## Notes
Mirrors the analogous [go-template#74](https://github.com/devantler-tech/go-template/pull/74) example enrichment so the two starter templates read consistently (portfolio consistency). XS, scaffolding-only — no product features.

Draft pending your promotion.