### PR TITLE
docs: reframe README around template usage and fix the stale Test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,61 @@
 # .NET Template
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Test](https://github.com/devantler-tech/dotnet-template/actions/workflows/test.yaml/badge.svg)](https://github.com/devantler-tech/dotnet-template/actions/workflows/test.yaml)
 
-A simple .NET template for new projects.
+A minimal, batteries-included .NET template for new projects and libraries. Skip the boilerplate — start from a clean, idiomatic scaffold with the house defaults, linting, CI/CD, releases, and agent tooling already wired up.
 
-## Prerequisites
+## ✨ What's included
 
-- [.NET](https://dotnet.microsoft.com/en-us/)
+- **Idiomatic scaffold** — an [`Example.slnx`](Example.slnx) solution wiring a library project ([`src/Example`](src/Example)) to a matching xUnit test project ([`tests/Example.Tests`](tests/Example.Tests)). A single documented member with tests shows the house testing pattern — rename `Example` to your own name and replace the example with your first type.
+- **House defaults** — every project builds with `Nullable`, `ImplicitUsings`, `AnalysisMode=All`, `EnforceCodeStyleInBuild`, XML documentation generation, and `TreatWarningsAsErrors` enabled, so code-style and analyzer findings are build errors, not warnings. Editor and analyzer rules live in [`.editorconfig`](.editorconfig).
+- **CI/CD** — a required-checks workflow on pull requests and the merge queue ([`ci.yaml`](.github/workflows/ci.yaml)); the .NET build/test validation runs via an org-required reusable workflow enforced by branch rules (run `dotnet build` / `dotnet test` locally before a PR).
+- **Releases & publishing** — merge [Conventional Commits](https://www.conventionalcommits.org/) to `main` and [semantic-release](https://github.com/semantic-release/semantic-release) cuts a `v*` tag and GitHub release ([`release.yaml`](.github/workflows/release.yaml)); that tag then publishes the library to NuGet via the shared [`publish-dotnet-library`](https://github.com/devantler-tech/reusable-workflows) workflow ([`publish.yaml`](.github/workflows/publish.yaml)).
+- **Dependency management** — [Dependabot](https://docs.github.com/code-security/dependabot) and [Renovate](https://docs.renovatebot.com/) keep dependencies and pinned GitHub Actions current.
+- **Agent-ready** — [`AGENTS.md`](AGENTS.md) conventions and a `.claude/skills/maintain` card so the autonomous Daily AI Assistant (and any agentic tool) can maintain the repo.
 
-## 🚀 Getting Started
+The target framework is declared in the project files — currently `net10.0` in [`src/Example/Example.csproj`](src/Example/Example.csproj).
 
-To get started, you can install the package from NuGet.
+## 🚀 Use this template
+
+Create a new repository from the template with the GitHub CLI:
 
 ```bash
-dotnet add package <package-name>
+gh repo create my-project --template devantler-tech/dotnet-template --public --clone
+cd my-project
+```
+
+Or click **Use this template** on the [repository page](https://github.com/devantler-tech/dotnet-template).
+
+Then make it your own — rename the solution, library project, namespace, and test project from `Example` to your project's name, and replace `ExampleClass` with your first type. A clean build and test confirms the scaffold is wired up:
+
+```bash
+dotnet build
+dotnet test
 ```
 
 ## 📝 Usage
 
-### Add a solution
+### Add a project to the solution
 
-```sh
-dotnet new sln --name <name-of-solution>
+```bash
+dotnet new classlib --output src/<name-of-project>
+dotnet sln Example.slnx add src/<name-of-project>
 ```
 
-### Add a project
+### Build your solution
 
-```sh
-dotnet new <project-type> --output folder1/folder2/<name-of-project>
-```
-
-### Add project to solution
-
-```sh
-dotnet sln add folder1/folder2/<name-of-project>
-```
-
-### Building your solution
-
-```sh
+```bash
 dotnet build
 ```
 
-### Running a project in your solution
+### Test your solution
 
-```sh
-dotnet run folder1/folder2/<name-of-project>
-```
-
-### Testing your solution
-
-```sh
+```bash
 dotnet test
 ```
+
+> Warnings are treated as errors, so a clean `dotnet build` and `dotnet test` are required before opening a pull request.
+
+## 🤖 Maintenance
+
+This template is maintained by an autonomous AI assistant. The conventions, validation commands, and contribution workflow live in [`AGENTS.md`](AGENTS.md).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #169. Part of the roadmap epic #167 (direction 2 — accurate, helpful docs). Mirrors the merged go-template README enrichment so the two templates read consistently.

## Problem
The README didn't read like the front door of a **template repository**:
- **Wrong adoption framing** — "Getting Started" told readers to `dotnet add package <package-name>` from NuGet, and "Usage" was generic `dotnet new`/`dotnet sln` boilerplate. This repo is a GitHub **template** (`is_template: true`) — the real entry point is **Use this template**, then renaming `Example`.
- **Broken badge** — the Test badge pointed at `…/actions/workflows/test.yaml`, but there is **no `test.yaml`** (workflows are `ci.yaml`, `publish.yaml`, `release.yaml`, `sync-labels.yaml`, `todos.yaml`), so it rendered a "not found" status.
- **Undocumented value** — the README never mentioned the house defaults, the validation/CI model, the release/publish flow, or the AI-maintenance setup.

## Change
- Rewrote **Getting Started → "Use this template"** around the template-usage flow (`gh repo create --template` / the Use this template button → rename `Example` → `dotnet build`/`dotnet test`).
- **Removed the stale Test badge.** `ci.yaml` only runs on `pull_request`/`merge_group` (not `push: main`), so a workflow badge wouldn't render a meaningful status on the default branch, and there's no published NuGet package or .NET-template badge analogous to go-template's Go-ecosystem badges. Kept the accurate License badge. (Acceptance criterion: *Test badge fixed or removed*.)
- Added a **"✨ What's included"** section grounded in the actual repo: house defaults (`Nullable`, `ImplicitUsings`, `AnalysisMode=All`, `EnforceCodeStyleInBuild`, XML docs, `TreatWarningsAsErrors`), the required-checks CI model + org-required reusable validation workflow, the semantic-release → `v*` tag → `publish-dotnet-library` (NuGet) flow, Dependabot/Renovate, and `AGENTS.md` + `.claude/skills/maintain`.
- Target framework deferred to the project file (currently `net10.0`) rather than hardcoded prose, mirroring go-template deferring the Go version to `go.mod`.

## Acceptance criteria
- ✅ README describes a **template repo** (no "install from NuGet" adoption framing).
- ✅ No broken badges (stale Test badge removed; License badge accurate).
- ✅ A new adopter can tell, from the README alone, what the scaffold provides and how to start.

## Validation
Docs-only; every relative link resolves against the repo tree (`Example.slnx`, `src/Example`, `tests/Example.Tests`, `.editorconfig`, the three workflow files, `AGENTS.md`). All facts (house-default properties, workflow triggers, release/publish chain) verified against `src/Example/Example.csproj`, the workflow YAML, `.releaserc`, and the `main` branch ruleset.