### PR TITLE
chore(pre-commit): format .NET code via a local dotnet-format hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
-# Pre-commit configuration for automatic .NET code formatting and linting
+# Pre-commit configuration for automatic .NET code formatting
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
-repos: []
+repos:
+  - repo: local
+    hooks:
+      - id: dotnet-format
+        name: Format .NET code with dotnet format
+        entry: dotnet format
+        language: system
+        files: '\.cs$'
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - `tests/Example.Tests/` — xUnit test project (`Example.Tests.csproj`, `ExampleClassTests.cs`) using `Microsoft.NET.Test.Sdk`, `coverlet.collector`, and `xunit.runner.visualstudio`.
 - `.editorconfig` — formatting and analyzer rules enforced at build.
 - `.github/workflows/` — `ci.yaml` (required-checks aggregation on PRs/merge queue), `publish.yaml` (publishes the NuGet library on `v*` tags via the reusable `publish-dotnet-library` workflow), `release.yaml`, `sync-labels.yaml`, `todos.yaml`.
-- `.pre-commit-config.yaml` — an empty/prepared pre-commit config (`repos: []`, no hooks configured yet); `.releaserc` — semantic-release configuration.
+- `.pre-commit-config.yaml` — a [pre-commit](https://pre-commit.com) config with a local `dotnet-format` hook that runs `dotnet format` on staged C# changes (opt in with `pre-commit install`); `.releaserc` — semantic-release configuration.
 
 ## Validation
 

--- a/src/Example/ExampleClass.cs
+++ b/src/Example/ExampleClass.cs
@@ -1,4 +1,4 @@
-﻿namespace Example;
+namespace Example;
 
 /// <summary>
 /// An example class that models the house conventions for this template: a single,

--- a/tests/Example.Tests/ExampleClassTests.cs
+++ b/tests/Example.Tests/ExampleClassTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Example.Tests;
+namespace Example.Tests;
 
 /// <summary>
 /// Tests for the <see cref="ExampleClass"/> class.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`.pre-commit-config.yaml` shipped **empty** (`repos: []`) while both its header comment and `AGENTS.md` promised *"automatic .NET code formatting"* — a no-op that delivers nothing. It also diverges from its sibling **[go-template](https://github.com/devantler-tech/go-template/blob/main/.pre-commit-config.yaml)**, which ships a *working* config (`golangci-lint-fmt` + a local hook). This is the pre-commit watch-item flagged in the [roadmap epic #167](https://github.com/devantler-tech/dotnet-template/issues/167) (*"either populate with a useful hook (e.g. `dotnet format`) or drop it"*).

## Change

Wire up the .NET equivalent of go-template's setup — a **local `dotnet-format` hook** (mirroring go-template's local-hook pattern) that runs `dotnet format` on staged C# changes:

```yaml
repos:
  - repo: local
    hooks:
      - id: dotnet-format
        name: Format .NET code with dotnet format
        entry: dotnet format
        language: system
        files: '\\.cs$'
        pass_filenames: false
```

Adopters opt in with `pre-commit install` and get format-on-commit that matches the template's `EnforceCodeStyleInBuild` / `TreatWarningsAsErrors` stance — catching formatting **locally** before it becomes a CI build error. `AGENTS.md` updated to describe the configured hook (was *"empty/prepared … no hooks configured yet"*).

## Real finding the hook surfaced

Running the new hook revealed pre-existing drift the in-build analyzers miss: **both example `.cs` files carried a UTF-8 BOM (`EF BB BF`)**, violating the repo's own `.editorconfig` `charset = utf-8` rule (charset/BOM normalization is a `dotnet format` concern, not a build-enforced analyzer rule, so it slipped past CI). Stripped the BOM so the scaffold is **`dotnet format`-clean** and the hook passes on first run for adopters.

## Validation (local, .NET 10.0.300 SDK)

- `pre-commit validate-config` ✅ · `yamllint` ✅ (only the cosmetic `document-start` warning, matching the original file and go-template's config)
- `pre-commit run dotnet-format --all-files` → **Failed once** (fixed the BOM drift), then **Passed clean** (idempotent) ✅
- `dotnet build -c Release` → **0 warnings, 0 errors** ✅ · `dotnet test -c Release` → **2 passed** ✅

## Notes

- Dev-convenience tooling only — no CI/build/release behaviour change; `chore:` so it does not cut a NuGet release.
- One coherent concern: the BOM fix is a prerequisite for the hook to pass out-of-box, not a mixed-in refactor.