### PR TITLE
chore: pin .NET SDK version via global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What
Add a `global.json` pinning the .NET SDK version for the template scaffold:

```json
{
  "sdk": {
    "version": "10.0.300",
    "rollForward": "latestFeature"
  }
}
```

## Why
The scaffold targets `net10.0` but pinned **no** SDK version, so builds resolved to whatever SDK happened to be installed on the dev machine or CI runner. The sibling **go-template** pins its toolchain **exactly** (`go 1.25.10`) — this brings the .NET template to parity with a deterministic, reproducible SDK anchor. dotnet-template's own `AGENTS.md` already calls for *"keep the toolchain version (.NET SDK) … current and aligned"*; `global.json` is the canonical, idiomatic mechanism for that, and fits the template's "minimal, idiomatic, current" bias (it's standard .NET scaffolding, not a product feature).

## Choices / trade-offs
- **`version: 10.0.300`** — the current .NET 10 feature band.
- **`rollForward: latestFeature`** — stays within .NET 10 (matching the `net10.0` TFM, never silently crossing to .NET 11) while tolerating a newer installed feature band so local devs aren't blocked. With `actions/setup-dotnet` honouring `global.json`, CI installs the pinned version exactly.
- **Maintenance:** Renovate (already configured here) keeps the pinned `version` current via its built-in `global.json` manager — no `renovate.json` change required.

## Validation
Built + tested locally against the pinned SDK (resolved `dotnet --version` → `10.0.300`):
- `dotnet build Example.slnx -c Release` → **0 errors, 0 warnings** (under `TreatWarningsAsErrors`).
- `dotnet test Example.slnx -c Release` → **2 passed, 0 failed**.