### PR TITLE
docs: add Copilot code-review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# GitHub Copilot review instructions — dotnet-template
+
+`devantler-tech/dotnet-template` is a **minimal .NET template**: an empty,
+idiomatic scaffold (a library project plus a matching xUnit test project) wired up
+with the house defaults and the standard CI/CD, release, and agent tooling, so a
+new package starts from a current baseline. Targets `net10.0`; published to NuGet
+on `v*` tags. Enforce the rules below when reviewing. They complement `AGENTS.md`
+(the canonical, cross-tool instructions) — keep both in sync; if a PR changes a
+convention here, it updates `AGENTS.md` too.
+
+## Scope & altitude
+- This is a **template, not a product** — flag any PR that adds application
+  features, business logic, or non-scaffold dependencies. The bias is minimal,
+  idiomatic, current.
+- `src/Example/` (`ExampleClass.cs`) and `tests/Example.Tests/`
+  (`ExampleClassTests.cs`) are an intentional sample meant to be renamed/replaced,
+  not a feature set. Don't approve filler code or extra projects added beyond the
+  one library + one test project.
+
+## .NET & toolchain
+- The repo builds with **warnings as errors** (`TreatWarningsAsErrors=true`,
+  `AnalysisMode=All`) and `Nullable`/`ImplicitUsings` enabled with XML-doc
+  generation — a clean `dotnet build` must produce **zero** warnings. Flag code
+  that suppresses analyzer warnings (`#pragma warning disable`, `<NoWarn>`) to
+  dodge a finding instead of fixing the root cause, and any new public API missing
+  XML docs.
+- Keep the target framework (`net10.0`) and SDK pinning aligned with the house
+  workflows — flag a hardcoded framework/SDK version in prose or workflows that
+  could drift.
+- Idiomatic, nullable-aware C#: no unjustified `!` null-forgiving operators, no
+  swallowed exceptions, `async`/`await` over blocking calls, tests via xUnit
+  `[Fact]`/`[Theory]`.
+
+## Format & analyzers
+- `.editorconfig` defines formatting and analyzer rules enforced at build; code
+  must pass `dotnet format`. The `.pre-commit-config.yaml` `dotnet-format` hook
+  runs it on staged C# — flag formatting drift.
+
+## Commits, CI & security
+- **PR titles must be Conventional Commits** (`feat:`/`fix:`/`chore:`/`docs:`/
+  `ci:`/`refactor:`/`test:`) — the repo squash-merges the title into the
+  changelog/release, so a non-conventional or bracket-prefixed title corrupts it.
+  Flag violations.
+- Workflow changes must pass `actionlint`. Pin third-party actions to a
+  full-length commit SHA, set least-privilege `permissions:`, and keep the house
+  workflows intact (`ci.yaml` is the required-checks aggregator; `publish.yaml`
+  publishes the NuGet library on `v*` tags via the reusable
+  `publish-dotnet-library` workflow). Flag unpinned actions and over-broad token
+  scopes.
+- Never weaken or skip a check to make CI pass (no skipped tests, `--no-verify`,
+  disabled steps, or "flaky"-dismissals) — fix the underlying cause.
+
+## Generated & config files
+- Don't hand-edit generated artifacts; re-run the generator instead. Keep the
+  `README` and badges accurate to what actually ships.
+
+Keep this file concise (≤ 4000 chars — Copilot review truncates beyond that) and
+in sync with `AGENTS.md`.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds `.github/copilot-instructions.md` to dotnet-template — the file **GitHub Copilot code review** actually reads (repo-wide), which `AGENTS.md` is *not*.

## Why

Copilot's code-review bot reads `.github/copilot-instructions.md` (+ any `.github/instructions/**/*.instructions.md`), **not** `AGENTS.md`. Without this file, Copilot reviews dotnet-template with no project context — missing the template-not-product altitude, the warnings-as-errors / nullable / XML-doc house defaults, the Conventional-Commit title requirement, and the SHA-pin/least-privilege workflow rules. This brings dotnet-template in line with the rollout tracked by [monorepo#1771](https://github.com/devantler-tech/monorepo/issues/1771), matching the merged siblings ([go-template](https://github.com/devantler-tech/go-template/blob/main/.github/copilot-instructions.md), actions, reusable-workflows).

## Details

- **3161 chars** — under the 4000-char limit beyond which Copilot review truncates.
- Concise, imperative, review-focused rules (not a dump of `AGENTS.md`) tailored to dotnet-template: template-not-product scope, the `src/Example` + `tests/Example.Tests` sample, warnings-as-errors / `AnalysisMode=All` / nullable / XML docs, `.editorconfig` + `dotnet format`, Conventional-Commit titles, `ci.yaml` required-checks aggregator + `publish.yaml` NuGet publish on `v*`, SHA-pinned least-privilege workflows.
- Cross-references `AGENTS.md` as canonical and asks both be kept in sync.

Docs-only; no code or workflow changes.