### PR TITLE
chore: apply 7-day Renovate release-age cooldown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     ":disableDependencyDashboard",
     ":semanticCommitTypeAll(fix)"
   ],
+  "minimumReleaseAge": "7 days",
   "github-actions": {
     "enabled": false
   },
@@ -13,5 +14,26 @@
   },
   "patch": {
     "automerge": true
-  }
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security",
+      "priority/high"
+    ],
+    "minimumReleaseAge": "0 days",
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "description": "Internal devantler-tech dependencies are trusted (our own code) — bump immediately with no release-age cooldown.",
+      "matchPackageNames": [
+        "devantler-tech/**",
+        "github.com/devantler-tech/**",
+        "ghcr.io/devantler-tech/**",
+        "@devantler-tech/**"
+      ],
+      "minimumReleaseAge": "0 days"
+    }
+  ]
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds a **7-day Renovate release-age cooldown** to `dotnet-template`, with the two
standard exemptions, bringing it in line with the rest of the portfolio.

```diff
+  "minimumReleaseAge": "7 days",
   "github-actions": { "enabled": false },
   "minor": { "automerge": true },
   "patch": { "automerge": true },
+  "vulnerabilityAlerts": {           // security fixes bypass the cooldown
+    "enabled": true,
+    "labels": ["security", "priority/high"],
+    "minimumReleaseAge": "0 days",
+    "automerge": true
+  },
+  "packageRules": [{                 // internal devantler-tech deps bypass the cooldown
+    "matchPackageNames": ["devantler-tech/**", "github.com/devantler-tech/**",
+                          "ghcr.io/devantler-tech/**", "@devantler-tech/**"],
+    "minimumReleaseAge": "0 days"
+  }]
```

## Why — portfolio consistency (holistic review)

`dotnet-template` was the **lone Renovate outlier with no release-age cooldown**. A
portfolio sweep of every `.github/renovate.json`:

| Repo | cooldown |
|---|---|
| `platform` | `minimumReleaseAge: 7 days` (+ `0 days` exemptions) |
| `platform-template` | `minimumReleaseAge: 7 days` (+ `0 days` exemptions) |
| **`dotnet-template`** | **none — `minor`/`patch` auto-merged instantly** |

The sibling **`go-template`** applies the same posture on the Dependabot side
(`cooldown: { default-days: 7, semver-major-days: 14 }`). So both templates *should*
hold third-party releases for 7 days before auto-merging — `dotnet-template` was the
one repo where a freshly-published (and potentially yanked/regressed) NuGet release
could be auto-merged the moment it landed.

This applies the **established dependency-cooldown policy** (it does **not** invent one):
- **`minimumReleaseAge: "7 days"`** — third-party deps wait a week before auto-merge.
- **internal `devantler-tech/**` deps exempt (`0 days`)** — our own code is trusted; bump
  immediately (matches the policy's internal-exemption rule).
- **security alerts exempt (`0 days`)** — required so the new cooldown doesn't *delay*
  `vulnerabilityAlerts`; these stay immediate + auto-merged, mirroring `platform-template`.

## Scope / non-goals

Single-concern. Deliberately **not** copied from `platform-template`: the flux/argocd/
kubernetes/helm managers, security-controller `packageRules`, Talos rules, and CLI
`customManagers` — all GitOps-specific and irrelevant to a .NET library scaffold.
Existing behaviour (no major auto-merge; `github-actions` handled by Dependabot) is
preserved unchanged.

## Validation

- `jq empty` → valid JSON.
- `renovate-config-validator` → **"Config validated successfully"**.
- Exemption package-name globs and `vulnerabilityAlerts` block are copied verbatim from
  the live `platform-template` config (already deployed and working).
