### PR TITLE
chore(deps): adopt xunit.v3 in the test project

### DIFF
--- a/tests/Example.Tests/Example.Tests.csproj
+++ b/tests/Example.Tests/Example.Tests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Migrate the example test project from **xunit v2** (`xunit` 2.9.3) to **`xunit.v3`** (3.2.2) — the current major xUnit line for new projects.

## Why

This is a project template: its whole job is to seed new repos on the **supported, idiomatic** toolchain. The scaffold already targets `net10.0` with `AnalysisMode=All` and `TreatWarningsAsErrors`, but the test project was still on the xUnit v2 maintenance line. xUnit v3 is the version the xUnit team recommends for new projects, so the template should model it. This matches the `dotnet-template` Maintenance brief: *"keep the scaffold minimal, idiomatic, and current."*

## Change

One line — swap the `xunit` 2.9.3 package for `xunit.v3` 3.2.2:

```diff
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
```

The migration is **self-contained**:
- The `Xunit` namespace and the `[Fact]` API are unchanged in v3, so `ExampleClassTests.cs` and `<Using Include="Xunit" />` need **no edits**.
- The existing `xunit.runner.visualstudio` (3.1.5) + `Microsoft.NET.Test.Sdk` (18.6.0) VSTest path keeps `dotnet test` working — **no workflow changes**.
- Docs (`README.md`, `AGENTS.md`, `copilot-instructions.md`) reference "xUnit" version-agnostically and stay accurate.

## Validation (local, .NET SDK 10.0.300)

- `dotnet build Example.slnx` → **0 errors, 0 warnings** (with `TreatWarningsAsErrors`).
- `dotnet test Example.slnx` → **2/2 passed**.

CI itself runs only the required-checks aggregator (this template validates via local `dotnet build`/`dotnet test` per its Maintenance section).