### PR TITLE
feat(scripts): add rename-placeholders.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal, batteries-included .NET template for new projects and libraries. Skip
 
 ## ✨ What's included
 
-- **Idiomatic scaffold** — an [`Example.slnx`](Example.slnx) solution wiring a library project ([`src/Example`](src/Example)) to a matching xUnit test project ([`tests/Example.Tests`](tests/Example.Tests)). A single documented member with tests shows the house testing pattern — rename `Example` to your own name and replace the example with your first type.
+- **Idiomatic scaffold** — an [`Example.slnx`](Example.slnx) solution wiring a library project ([`src/Example`](src/Example)) to a matching xUnit test project ([`tests/Example.Tests`](tests/Example.Tests)). A single documented member with tests shows the house testing pattern; [`scripts/rename-placeholders.sh`](scripts/rename-placeholders.sh) repoints the `Example` scaffold to your own project name in one shot.
 - **House defaults** — every project builds with `Nullable`, `ImplicitUsings`, `AnalysisMode=All`, `EnforceCodeStyleInBuild`, XML documentation generation, and `TreatWarningsAsErrors` enabled, so code-style and analyzer findings are build errors, not warnings. Editor and analyzer rules live in [`.editorconfig`](.editorconfig).
 - **CI/CD** — a required-checks workflow on pull requests and the merge queue ([`ci.yaml`](.github/workflows/ci.yaml)); the .NET build/test validation runs via an org-required reusable workflow enforced by branch rules (run `dotnet build` / `dotnet test` locally before a PR).
 - **Releases & publishing** — merge [Conventional Commits](https://www.conventionalcommits.org/) to `main` and [semantic-release](https://github.com/semantic-release/semantic-release) cuts a `v*` tag and GitHub release ([`release.yaml`](.github/workflows/release.yaml)); that tag then publishes the library to NuGet via the shared [`publish-dotnet-library`](https://github.com/devantler-tech/reusable-workflows) workflow ([`publish.yaml`](.github/workflows/publish.yaml)).
@@ -26,12 +26,15 @@ cd my-project
 
 Or click **Use this template** on the [repository page](https://github.com/devantler-tech/dotnet-template).
 
-Then make it your own — rename the solution, library project, namespace, and test project from `Example` to your project's name, and replace `ExampleClass` with your first type. A clean build and test confirms the scaffold is wired up:
+Then make it your own — run the personalisation script to repoint the scaffold (solution, projects, namespaces, and README references) to your project's name in one shot, then replace the sample `ExampleClass` with your first real type. A clean build and test confirms the scaffold is wired up:
 
 ```bash
+./scripts/rename-placeholders.sh <ProjectName>   # e.g. Widget
 dotnet build
 dotnet test
 ```
+
+Run the script with no argument to derive a PascalCase name from your `origin` GitHub remote. It leaves the **Use this template** links above and the maintenance docs untouched; review the result with `git diff`. (Prefer to rename by hand? Repoint `Example` across the `.slnx`, `src/`, `tests/`, and README references yourself.)
 
 ## 📝 Usage
 

--- a/scripts/rename-placeholders.sh
+++ b/scripts/rename-placeholders.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env sh
+# rename-placeholders.sh — turn this scaffold into your own project in one shot.
+#
+# Fresh from `Use this template`, the scaffold is named `Example`: an
+# `Example.slnx` solution wiring `src/Example` (`Example.csproj` + `ExampleClass.cs`)
+# to `tests/Example.Tests` (`Example.Tests.csproj` + `ExampleClassTests.cs`). That
+# `Example` placeholder shows up as directory names, file names, the solution name,
+# `<Project Path>` / `<ProjectReference>` paths, and `namespace` / type identifiers.
+# Repointing it all by hand is tedious and easy to get half-wrong — a missed
+# reference yields a confusing build error on first use — so this script renames
+# every `Example` across the solution (.slnx), projects (.csproj), code (.cs) and
+# the README in one shot, WITHOUT touching the references that must keep pointing
+# at the upstream template:
+#   • README's "Use this template" links (`--template devantler-tech/dotnet-template`
+#     and the `[repository page]` link) name where the template lives — they carry
+#     the `dotnet-template` token, never `Example`, so a rename leaves them intact.
+# It also deliberately leaves the maintenance docs (`AGENTS.md`,
+# `.github/copilot-instructions.md`): those describe template-upkeep conventions,
+# not your code, and are yours to adapt.
+#
+# Usage:  scripts/rename-placeholders.sh [ProjectName]
+#   e.g.  scripts/rename-placeholders.sh Widget   ->  Widget.slnx, src/Widget, …
+# With no argument it derives a PascalCase name from origin's GitHub repo name.
+set -eu
+
+OLD="Example"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# --- resolve the new project name -------------------------------------------
+new_name="${1:-}"
+if [ -z "$new_name" ]; then
+  remote="$(git -C "$repo_root" remote get-url origin 2>/dev/null || true)"
+  case "$remote" in
+  *github.com[:/]*)
+    repo="${remote##*/}" # owner/repo -> repo
+    repo="${repo%.git}"
+    # PascalCase: split the repo name on - _ . and capitalise each segment, so
+    # `my-cool-app` -> `MyCoolApp` (an idiomatic .NET project name).
+    new_name="$(printf '%s' "$repo" | awk 'BEGIN { RS = "[-_.]"; ORS = "" } { if (length($0) > 0) print toupper(substr($0, 1, 1)) substr($0, 2) }')"
+    ;;
+  esac
+fi
+
+if [ -z "$new_name" ]; then
+  echo "usage: scripts/rename-placeholders.sh <ProjectName>" >&2
+  echo "       e.g. scripts/rename-placeholders.sh Widget" >&2
+  echo "       (could not derive a name from origin's GitHub remote)." >&2
+  exit 1
+fi
+
+if [ "$new_name" = "$OLD" ]; then
+  echo "error: the new name equals the template's own ($OLD)." >&2
+  echo "       run this in a project created from the template, with your own name." >&2
+  exit 1
+fi
+
+# A .NET project / namespace identifier: letter or underscore start, optionally
+# dotted (e.g. Widget or Acme.Widget). Reject anything that is not one — it would
+# yield an invalid namespace or an unbuildable project.
+if ! printf '%s' "$new_name" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$'; then
+  echo "error: '$new_name' is not a valid .NET project name (an identifier, optionally dotted)." >&2
+  echo "       e.g. Widget or Acme.Widget" >&2
+  exit 1
+fi
+
+# `Example` plays two roles: the solution / project / namespace name (which may be
+# dotted, e.g. `Acme.Widget`) and the sample *type* prefix (`ExampleClass`,
+# `ExampleClassTests`), which must stay a single identifier — a C# type name cannot
+# contain a dot. So derive a dot-free token for the type names; for a non-dotted
+# project name it is identical, leaving that common case unchanged.
+type_token="$(printf '%s' "$new_name" | tr -d '.')"
+
+cd "$repo_root"
+
+# Use `git mv` when the tree is a git repo so history follows the renames; fall
+# back to a plain `mv` otherwise.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  use_git_mv=1
+else
+  use_git_mv=0
+fi
+
+move() {
+  # move SRC DST — skip silently if SRC is absent, so re-runs are idempotent.
+  [ -e "$1" ] || return 0
+  if [ "$use_git_mv" = 1 ]; then
+    git mv "$1" "$2"
+  else
+    mv "$1" "$2"
+  fi
+}
+
+# --- 1) rename directories and files (dir first, then its contents) ---------
+move "src/$OLD" "src/$new_name"
+move "src/$new_name/$OLD.csproj" "src/$new_name/$new_name.csproj"
+move "src/$new_name/${OLD}Class.cs" "src/$new_name/${type_token}Class.cs"
+move "tests/$OLD.Tests" "tests/$new_name.Tests"
+move "tests/$new_name.Tests/$OLD.Tests.csproj" "tests/$new_name.Tests/$new_name.Tests.csproj"
+move "tests/$new_name.Tests/${OLD}ClassTests.cs" "tests/$new_name.Tests/${type_token}ClassTests.cs"
+move "$OLD.slnx" "$new_name.slnx"
+
+# --- 2) rewrite file contents (solution, projects, code, README) ------------
+# `$OLD`, `$new_name` and `$type_token` are validated identifiers (no `/` or sed
+# metacharacters), so plain `s///g` substitutions are safe. Two passes, in order:
+# first the type names (`ExampleClass`/`ExampleClassTests` -> the dot-free token),
+# then everything else (`Example` -> the project name). The first pass must run
+# before the second so a dotted project name never leaks a dot into a type name.
+# Write to a temp file and `mv` rather than `sed -i`, whose syntax differs between
+# GNU and BSD (macOS) sed.
+changed=0
+subst() {
+  f="$1"
+  [ -f "$f" ] || return 0
+  tmp="$f.rename.$$"
+  sed -e "s/${OLD}Class/${type_token}Class/g" -e "s/$OLD/$new_name/g" "$f" >"$tmp"
+  if cmp -s "$f" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv "$tmp" "$f"
+    changed=$((changed + 1))
+  fi
+}
+
+subst "$new_name.slnx"
+subst "src/$new_name/$new_name.csproj"
+subst "src/$new_name/${type_token}Class.cs"
+subst "tests/$new_name.Tests/$new_name.Tests.csproj"
+subst "tests/$new_name.Tests/${type_token}ClassTests.cs"
+subst "README.md"
+
+echo "renamed $OLD -> $new_name across $changed file(s) (plus directory/file renames)."
+echo "next: review 'git diff', then 'dotnet build && dotnet test'."


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #219 (dotnet-template roadmap epic #218, theme 1 — onboarding friction). Direct parity with the sibling go-template's [`scripts/rename-placeholders.sh` (#107)](https://github.com/devantler-tech/go-template/pull/107).

## Problem
Adopting the template is a manual chore: the README tells you to "rename the solution, library project, namespace, and test project from `Example` to your project's name". That touches `Example.slnx`, `src/Example/` (dir + `.csproj`), `tests/Example.Tests/` (dir + `.csproj`), the `namespace`/type identifiers in two `.cs` files, the `<ProjectReference>`/`<Project Path>` entries, and the README — easy to get half-wrong, and a missed reference yields a confusing build error on first use.

## What this adds
A dependency-free POSIX `sh` script (`scripts/rename-placeholders.sh`, matching go-template's so the template suite stays consistent) that, given a project name:
- renames the `src/Example` + `tests/Example.Tests` directories, their `.csproj` files, and the sample `.cs` files;
- renames `Example.slnx` and rewrites the `<Project Path>`/`<ProjectReference>` paths inside the solution and test project;
- rewrites `namespace Example` / `namespace Example.Tests` and the sample type names across the `.cs` files;
- updates the README's `Example` references;
- **deliberately preserves** the upstream **Use this template** links (`--template devantler-tech/dotnet-template` + the repository-page link) — those carry the `dotnet-template` token, never `Example`, so a rename leaves them intact (the exact trap that bit go-template #107).

The new name comes from an argument, or is derived as a PascalCase name from the `origin` GitHub remote (`my-cool-app` → `MyCoolApp`). It validates the name is a legal .NET identifier (optionally dotted) and refuses both invalid names and the template's own `Example`.

## Two roles of `Example` — the dotted-name fix
Testing caught a real bug the issue anticipated: `Example` is both the **project/namespace** name (dotted allowed, e.g. `Acme.Widget`) *and* the **type** prefix (`ExampleClass`), which must stay a single identifier — a C# type name cannot contain a dot. A naive blanket substitution produced `Acme.WidgetClass` (uncompilable). Fixed with a two-pass substitution: type names use a dot-stripped token (`AcmeWidgetClass` in namespace `Acme.Widget`), everything else uses the full name. For a non-dotted name the two tokens are identical, so the common case is unchanged.

## Validation
- `shellcheck` clean; `shfmt` clean against the repo `.editorconfig` (2-space, no tabs).
- End-to-end on fresh clones for three name shapes — `Widget` (arg), `Acme.Widget` (dotted arg), and `my-cool-app` → `MyCoolApp` (no-arg remote derivation): each leaves **zero** `Example` references outside the deliberately-untouched maintenance docs, and **`dotnet build` + `dotnet test` pass** (2/2 tests, 0 warnings under `TreatWarningsAsErrors`).
- Edge cases rejected: invalid name (`123-bad`) and the template's own name (`Example`).

## Scope note
Intentionally leaves `AGENTS.md` and `.github/copilot-instructions.md` (they describe template-upkeep conventions, not the adopter's code) and the upstream template links — matching the acceptance criteria (`.slnx`, `.csproj`, `.cs`, README) and go-template's conservative "touch only what's needed" approach.